### PR TITLE
Twitter認証を使ってログイン、アカウント作成できるようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,5 +58,6 @@ gem 'metainspector'
 gem 'omniauth'
 gem 'omniauth-google-oauth2'
 gem 'omniauth-rails_csrf_protection'
+gem 'omniauth-twitter'
 gem 'slim-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
+    oauth (0.5.10)
     oauth2 (1.4.9)
       faraday (>= 0.17.3, < 3.0)
       jwt (>= 1.0, < 3.0)
@@ -194,12 +195,18 @@ GEM
       oauth2 (~> 1.1)
       omniauth (~> 2.0)
       omniauth-oauth2 (~> 1.7.1)
+    omniauth-oauth (1.2.0)
+      oauth
+      omniauth (>= 1.0, < 3)
     omniauth-oauth2 (1.7.2)
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
     omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
+    omniauth-twitter (1.4.0)
+      omniauth-oauth (~> 1.1)
+      rack
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -374,6 +381,7 @@ DEPENDENCIES
   omniauth
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
+  omniauth-twitter
   pg (~> 1.1)
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,12 +5,13 @@ class SessionsController < ApplicationController
 
   def create
     auth_hash = request.env['omniauth.auth']
-    user = User.from_omniauth(auth_hash)
+    user = User.find_from_omniauth(auth_hash)
     if user
       sign_in(user)
       redirect_to root_path, notice: 'ログインしました'
     else
-      redirect_to signup_path(auth_hash)
+      @user = User.new_from_omniauth(auth_hash)
+      render 'users/new'
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,13 +3,7 @@
 class UsersController < ApplicationController
   before_action :set_user, only: %i[show edit update destroy]
 
-  def new
-    @user = User.new
-    @user.name = params[:info][:name]
-    @user.icon_url = params[:info][:image]
-    @user.provider = params[:provider]
-    @user.uid = params[:uid]
-  end
+  def new; end
 
   def show; end
 
@@ -35,7 +29,7 @@ class UsersController < ApplicationController
 
   def destroy
     @user.destroy
-    edirect_to root_path, notice: 'アカウントを削除しました'
+    redirect_to root_path, notice: 'アカウントを削除しました'
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,10 +5,19 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
 
-  def self.from_omniauth(auth_hash)
-    provider = auth_hash[:provider]
-    uid = auth_hash[:uid]
+  def self.find_from_omniauth(auth_hash)
+    provider = auth_hash.provider
+    uid = auth_hash.uid
     User.where(provider: provider, uid: uid).first
+  end
+
+  def self.new_from_omniauth(auth_hash)
+    User.new(
+      name: auth_hash.info.name,
+      icon_url: auth_hash.info.image,
+      provider: auth_hash.provider,
+      uid: auth_hash.uid
+    )
   end
 
   def liked?(post)

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -14,3 +14,4 @@ table
       td = post.likes.count
 
 p = button_to 'Googleでアカウント登録', '/auth/google_oauth2', method: :post, data: { turbo: false }
+p = button_to 'Twitterでアカウント登録', '/auth/twitter', method: :post, data: { turbo: false }

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -1,2 +1,3 @@
 h1 ログイン
 p = button_to 'Googleでログイン', '/auth/google_oauth2', method: :post, data: { turbo: false }
+p = button_to 'Twitterでログイン', '/auth/twitter', method: :post, data: { turbo: false }

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,9 +1,13 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   if Rails.env.development? || Rails.env.test?
     provider :google_oauth2, ENV['GOOGLE_ID'], ENV['GOOGLE_SECRET']
+    provider :twitter, ENV['TWITTER_ID'], ENV['TWITTER_SECRET']
   else
     provider :google_oauth2,
       Rails.application.credentials.google[:client_id],
       Rails.application.credentials.google[:client_secret]
+    provider :twitter,
+      Rails.application.credentials.twitter[:client_id],
+      Rails.application.credentials.twitter[:client_secret]
   end
 end


### PR DESCRIPTION
- #38 
omniauth-twitterを使ってログイン、アカウント作成できるようにした
ユーザーが存在しなかった場合、users/newをrenderする形に修正した