### PR TITLE
omniauth-twitterから取得する画像を大きいものに変更した

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  before_action :signin_required, only: %i[new create edit update destroy]
+  before_action :signin_required, only: %i[new edit update destroy]
   before_action :set_user, only: %i[show update destroy]
 
   def new; end

--- a/app/views/shared/_description.slim
+++ b/app/views/shared/_description.slim
@@ -33,9 +33,9 @@
         = form_with(model: @post, local: true) do |form|
           .modal-card-body
             .content
-              - if @post.errors.present?
-                - @post.errors.full_messages.each do |message|
-                  = message
+              / - if @post.errors.present?
+              /   - @post.errors.full_messages.each do |message|
+              /     = message
               .field.has-text-left
                 = form.label :url, class: 'label'
               .field-body.is-grouped

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,13 +1,14 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   if Rails.env.development? || Rails.env.test?
     provider :google_oauth2, ENV['GOOGLE_ID'], ENV['GOOGLE_SECRET']
-    provider :twitter, ENV['TWITTER_ID'], ENV['TWITTER_SECRET']
+    provider :twitter, ENV['TWITTER_ID'], ENV['TWITTER_SECRET'], { :image_size => 'original' }
   else
     provider :google_oauth2,
       Rails.application.credentials.google[:client_id],
       Rails.application.credentials.google[:client_secret]
     provider :twitter,
       Rails.application.credentials.twitter[:client_id],
-      Rails.application.credentials.twitter[:client_secret]
+      Rails.application.credentials.twitter[:client_secret],
+      { :image_size => 'original' }
   end
 end


### PR DESCRIPTION
- #64 

omniauth-twitterから取得する画像を大きいものに変更
<img width="260" alt="image" src="https://user-images.githubusercontent.com/69446373/177309786-c5ad37c6-c6e0-4e3f-aa1d-14ece5815d9b.png">
