### PR TITLE
モバイル対応できるようCSSを修正した

### DIFF
--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -2,7 +2,7 @@
 
 class API::PostsController < ApplicationController
   def index
-    @posts = Post.includes(:comments, :likes).sort { |a, b| b.likes.size <=> a.likes.size }
+    @posts = Post.includes(:comments, :likes)
   end
 
   def destroy

--- a/app/javascript/packs/application.scss
+++ b/app/javascript/packs/application.scss
@@ -22,6 +22,7 @@ $danger: $orange;
 $body-background-color: $white;
 $control-border-width: 2px;
 $input-shadow: none;
+$section-padding: 20px;
 @import '../stylesheets/description.scss';
 @import '../stylesheets/post_index.scss';
 @import '../stylesheets/modal.scss';

--- a/app/javascript/posts.vue
+++ b/app/javascript/posts.vue
@@ -71,12 +71,9 @@ export default {
     },
     sortPopular() {
       this.posts = this.posts.sort((a, b) => {
-        if (a.likes_count > b.likes_count)
-          return -1
-        else if (a.likes_count < b.likes_count)
-          return 1
-        else
-          return new Date(a.created_at) < new Date(b.created_at) ? -1 : 1
+        if (a.likes_count > b.likes_count) return -1
+        else if (a.likes_count < b.likes_count) return 1
+        else return new Date(a.created_at) < new Date(b.created_at) ? -1 : 1
       })
       this.isOrder = 'popular'
     }

--- a/app/javascript/posts.vue
+++ b/app/javascript/posts.vue
@@ -60,6 +60,7 @@ export default {
         .then((response) => response.json())
         .then((json) => {
           this.posts = json.posts
+          this.sortPopular()
         })
     },
     sortNewest() {
@@ -70,7 +71,12 @@ export default {
     },
     sortPopular() {
       this.posts = this.posts.sort((a, b) => {
-        return a.likes_count > b.likes_count ? -1 : 1
+        if (a.likes_count > b.likes_count)
+          return -1
+        else if (a.likes_count < b.likes_count)
+          return 1
+        else
+          return new Date(a.created_at) < new Date(b.created_at) ? -1 : 1
       })
       this.isOrder = 'popular'
     }

--- a/app/javascript/stylesheets/notification.scss
+++ b/app/javascript/stylesheets/notification.scss
@@ -1,8 +1,3 @@
-.notification {
-  text-align: center;
-  margin-bottom: 3.5rem;
-}
-
 .v-toast__item--success {
   background-color: $blue;
 }

--- a/app/javascript/stylesheets/post_index.scss
+++ b/app/javascript/stylesheets/post_index.scss
@@ -24,3 +24,13 @@
   letter-spacing: 3px;
   margin-right: 2px;
 }
+
+.post-list {
+  display: flex;
+  column-gap: 10px;
+  margin-top: 4px;
+}
+
+.post-separator {
+  margin: 12px 0;
+}

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -16,10 +16,10 @@ html
       = render 'shared/header'
     main
       - if notice.presence
-        .notification.is-primary
+        .notification.is-primary.has-text-centered
           = notice
       - if alert.presence
-        .notification.is-danger
+        .notification.is-danger.has-text-centered
           = alert
       = render 'shared/description'
     .container

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -23,12 +23,15 @@ article.section
       p = @post.likes.count
       - if current_user == @post.user
         = link_to '記事の削除', @post, method: :delete, data: { confirm: "「#{@post.title}」を削除してもよろしいですか？" }
-  .content
+  .post-list
     | 投稿 :
-    = link_to image_tag(User.find(@post.user_id).icon_url, size: '28x28'), user_path(@post.user_id), style: 'margin-left: 3px;'
-    = link_to User.find(@post.user_id).name, user_path(@post.user_id), style: 'margin: 0px 3px 0px 3px;'
-    = l @post.created_at, format: :short
-  hr
+    .post-list-item
+      = link_to image_tag(User.find(@post.user_id).icon_url, size: '28x28'), user_path(@post.user_id)
+    .post-list-item
+      = link_to User.find(@post.user_id).name, user_path(@post.user_id)
+    .post-list-item
+      = l @post.created_at, format: :short
+  hr.post-separator
   .content
     - if @comments.presence
       - @comments.each do |comment|

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -7,13 +7,9 @@ article.section
       .title.is-5
         = link_to @post.title, @post.url
       .sub-title
-        = link_to @post
-          i.fa-solid.fa-message
-        = link_to @post.comments.count, @post, style: 'margin-left: 3px;'
+        i.fa-solid.fa-message
+        |  #{@post.comments.count}
         |  #{@post.site_name}
-        = link_to image_tag(User.find(@post.user_id).icon_url, size: '28x28'), user_path(@post.user_id), style: 'margin-left: 3px;'
-        = link_to User.find(@post.user_id).name, user_path(@post.user_id), style: 'margin: 0px 3px 0px 3px;'
-        = l @post.created_at, format: :short
     .media-right.has-text-centered
       - if current_user
         - if current_user.liked?(@post)
@@ -27,7 +23,13 @@ article.section
       p = @post.likes.count
       - if current_user == @post.user
         = link_to '記事の削除', @post, method: :delete, data: { confirm: "「#{@post.title}」を削除してもよろしいですか？" }
-  .section
+  .content
+    | 投稿 :
+    = link_to image_tag(User.find(@post.user_id).icon_url, size: '28x28'), user_path(@post.user_id), style: 'margin-left: 3px;'
+    = link_to User.find(@post.user_id).name, user_path(@post.user_id), style: 'margin: 0px 3px 0px 3px;'
+    = l @post.created_at, format: :short
+  hr
+  .content
     - if @comments.presence
       - @comments.each do |comment|
         .media
@@ -42,7 +44,7 @@ article.section
     - else
       p
         | まだこの記事にコメントはありません
-  .section
+  .content
     - if signed_in?
       = form_with(model: [@post, @comment], local: true) do |form|
         .field.is-horizontal

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -4,13 +4,14 @@
       .image.is-128x128
         = image_tag @user.icon_url
     .media-content
-        .title.is-3
+      .content
+        .title.is-4
           = @user.name
         .sub-title
           = link_to @user.url, @user.url
-    .media-right
-      - if current_user == @user
-        = link_to 'アカウント編集', current_user_edit_path, class: 'button'
+      .content
+        - if current_user == @user
+          = link_to 'アカウント編集', current_user_edit_path, class: 'button'
 
 - if current_user
   #js-user-posts(data-user-id=params[:id] data-current-user-id=current_user.id)

--- a/bin/lint
+++ b/bin/lint
@@ -3,3 +3,4 @@
 bundle exec rubocop -a
 bundle exec slim-lint app/views -c config/slim_lint.yml
 bin/yarn lint
+yarn prettier app/javascript/*.{js,vue} --write


### PR DESCRIPTION
- #95 

<img width="393" alt="image" src="https://user-images.githubusercontent.com/69446373/184294510-fde52f95-2eba-4eab-acfe-26037aa2d11b.png">

・ユーザーページにて名前を横書きに、編集ボタンの位置を調整した
・sectionクラスのpaddingの修正
・人気順にていいねの数が同数だった場合、古い記事が上にソートされるよう統一した
・`bin/setup`でprettierの修正をできるようにした