### PR TITLE
ヘッダーのレスポンシブ対応

### DIFF
--- a/app/javascript/menu.js
+++ b/app/javascript/menu.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const element = document.querySelector('#js-menu')
+  element.addEventListener('click', () => {
+    const menu = document.querySelector('#nav-menu')
+    element.classList.toggle('is-active')
+    menu.classList.toggle('is-active')
+  })
+})

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -2,5 +2,6 @@ import Rails from '@rails/ujs'
 import '../posts.js'
 import '../user.js'
 import '../modal.js'
+import '../menu.js'
 
 Rails.start()

--- a/app/javascript/stylesheets/header.scss
+++ b/app/javascript/stylesheets/header.scss
@@ -1,8 +1,3 @@
-$navbar-breakpoint: 0px;
+$navbar-breakpoint: 400px;
 $navbar-background-color: none;
-$navbar-height: 4rem;
-
-.navbar-end {
-  position: absolute;
-  right: 0px;
-}
+// $navbar-item-img-max-height: 64px;

--- a/app/javascript/stylesheets/header.scss
+++ b/app/javascript/stylesheets/header.scss
@@ -1,3 +1,13 @@
-$navbar-breakpoint: 400px;
+$navbar-breakpoint: 370px;
 $navbar-background-color: none;
-// $navbar-item-img-max-height: 64px;
+$navbar-item-img-max-height: 56px;
+
+.header-log {
+  width: 180px;
+  height: 28px;
+}
+
+.signout-button {
+  margin-right: 0.5rem;
+  margin-bottom: 0px;
+}

--- a/app/views/home/_header.html.slim
+++ b/app/views/home/_header.html.slim
@@ -3,8 +3,8 @@ nav.navbar role="navigation" aria-label="main navigation"
     .navbar-brand
       .navbar-item
         - unless request.path == '/'
-          h1.image
-            = link_to image_tag('nursepicks_head.png', alt: 'header_logo', size: '180x28'), root_path
+          h1.image.header-log
+            = link_to image_tag('nursepicks_head.png', alt: 'header_logo'), root_path
       a.navbar-burger#js-menu data-target='nav-menu' role="button" aria-label="menu" aria-expanded="false"
         span aria-hidden="true"
         span aria-hidden="true"
@@ -14,11 +14,10 @@ nav.navbar role="navigation" aria-label="main navigation"
       .navbar-end
         - if signed_in?
           .navbar-item.is-white
-            .buttons
-              button.button
-                = link_to 'ログアウト', signout_path, method: :delete
-              .image.is-64x64
-                = link_to image_tag(current_user.icon_url, alt: 'nav_user_icon'), current_user
+            button.button.signout-button
+              = link_to 'ログアウト', signout_path, method: :delete
+            .icon-image
+              = link_to image_tag(current_user.icon_url, alt: 'nav_user_icon'), current_user
         - else
           .navbar-item.is-white
             .buttons

--- a/app/views/home/_header.html.slim
+++ b/app/views/home/_header.html.slim
@@ -1,47 +1,54 @@
-header.navbar.is-bold
+nav.navbar role="navigation" aria-label="main navigation"
   .container
-    - unless request.path == '/'
-      .navbar-brand
-        .navbar-item
+    .navbar-brand
+      .navbar-item
+        - unless request.path == '/'
           h1.image
-            = link_to image_tag('nursepicks_head.png', alt: 'header_logo'), root_path
-    nav.navbar-menu
+            = link_to image_tag('nursepicks_head.png', alt: 'header_logo', size: '180x28'), root_path
+      a.navbar-burger#js-menu data-target='nav-menu' role="button" aria-label="menu" aria-expanded="false"
+        span aria-hidden="true"
+        span aria-hidden="true"
+        span aria-hidden="true"
+
+    .navbar-menu#nav-menu
       .navbar-end
         - if signed_in?
           .navbar-item.is-white
-            button.button
-              = link_to 'ログアウト', signout_path, method: :delete
-          .image.is-64x64
-            = link_to image_tag(current_user.icon_url, alt: 'nav_user_icon'), current_user
+            .buttons
+              button.button
+                = link_to 'ログアウト', signout_path, method: :delete
+              .image.is-64x64
+                = link_to image_tag(current_user.icon_url, alt: 'nav_user_icon'), current_user
         - else
           .navbar-item.is-white
-            button.button.mr-1#js-modal data-modal='signup'
-              | ユーザー登録
-            .modal#signup
-              .modal-background#js-modal data-modal='signup'
-              .modal-card
-                .modal-card-head
-                  p.modal-card-title
-                    | ユーザー登録
-                  button.delete#js-modal aria-label="close" data-modal='signup'
-                .modal-card-body
-                  .buttons.is-centered
-                    .button.is-large
-                      = link_to 'Googleで新規登録', '/auth/google_oauth2', method: :post, data: { turbo: false }
-                    .button.is-large
-                      = link_to 'Twitterで新規登録', '/auth/twitter', method: :post, data: { turbo: false }
-            button.button.is-info#js-modal data-modal='signin'
-              | ログイン
-            .modal#signin
-              .modal-background#js-modal data-modal='signin'
-              .modal-card
-                .modal-card-head
-                  p.modal-card-title
-                    | ログイン
-                  button.delete#js-modal aria-label="close" data-modal='signin'
-                .modal-card-body
-                  .buttons.is-centered
-                    .button.is-large.is-primary
-                      = link_to 'Googleでログイン', '/auth/google_oauth2', method: :post, data: { turbo: false }, class: 'link-button'
-                    .button.is-large.is-primary
-                      = link_to 'Twitterでログイン', '/auth/twitter', method: :post, data: { turbo: false }, class: 'link-button'
+            .buttons
+              button.button.mr-1#js-modal data-modal='signup'
+                | ユーザー登録
+              .modal#signup
+                .modal-background#js-modal data-modal='signup'
+                .modal-card
+                  .modal-card-head
+                    p.modal-card-title
+                      | ユーザー登録
+                    button.delete#js-modal aria-label="close" data-modal='signup'
+                  .modal-card-body
+                    .buttons.is-centered
+                      .button.is-large
+                        = link_to 'Googleで新規登録', '/auth/google_oauth2', method: :post, data: { turbo: false }
+                      .button.is-large
+                        = link_to 'Twitterで新規登録', '/auth/twitter', method: :post, data: { turbo: false }
+              button.button.is-info#js-modal data-modal='signin'
+                | ログイン
+              .modal#signin
+                .modal-background#js-modal data-modal='signin'
+                .modal-card
+                  .modal-card-head
+                    p.modal-card-title
+                      | ログイン
+                    button.delete#js-modal aria-label="close" data-modal='signin'
+                  .modal-card-body
+                    .buttons.is-centered
+                      .button.is-large.is-primary
+                        = link_to 'Googleでログイン', '/auth/google_oauth2', method: :post, data: { turbo: false }, class: 'link-button'
+                      .button.is-large.is-primary
+                        = link_to 'Twitterでログイン', '/auth/twitter', method: :post, data: { turbo: false }, class: 'link-button'


### PR DESCRIPTION
- #95 

・本番環境でヘッダーロゴが引き伸ばされてしまっていたので、画像は固定とした
・ヘッダーロゴとログインボタン等のその他のアイテムが重なって表示されてしまうため、結局ハンバーガーメニューを作成し対応した
・$navbar-breakpointの370はiPhoneSEで対応できる値とした

https://user-images.githubusercontent.com/69446373/187569646-0a81fcfe-862a-4f91-a73c-ead1ffb5792c.mov

