### PR TITLE
無効な記事が投稿された時に例外処理を行うようにした

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the comments controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the home controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/likes.scss
+++ b/app/assets/stylesheets/likes.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the likes controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the posts controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/sessions.scss
+++ b/app/assets/stylesheets/sessions.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the sessions controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the users controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module CommentsHelper
-end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module HomeHelper
-end

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module LikesHelper
-end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module PostsHelper
-end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module SessionsHelper
-end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module UsersHelper
-end

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -68,4 +68,4 @@ article.article.container
       p
         | ログインするとコメントすることができます
 
-  = link_to '戻る', posts_path
+  = link_to '戻る', root_path

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,7 @@ Bundler.require(*Rails.groups)
 module Nursepicks
   class Application < Rails::Application
     config.i18n.default_locale = :ja
+    config.active_model.i18n_customize_full_message = true
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -10,7 +10,7 @@ ja:
       post:
         image_url: 画像のURL  #g
         site_name: サイト名  #g
-        title: 題名  #g
+        title: 記事
         url: URL  #g
         user: :activerecord.models.user  #g
         comments: コメント  #g
@@ -34,3 +34,12 @@ ja:
       like:
         post: :activerecord.models.post  #g
         user: :activerecord.models.user  #g
+
+    errors:
+      # format: '%{message}'
+      models:
+        post:
+          attributes:
+            title:
+              format: '%{message}'
+              blank: この記事の投稿は難しいようです

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 
 Rails.application.routes.draw do
   root 'posts#index'
-  resources :posts, except: %i[new edit update] do
+  resources :posts, only: %i[show create destroy] do
     resources :comments, only: %i(create destroy)
     resource :likes, only: %i(create destroy)
   end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Post, type: :model do
   it 'タイトルがなければ記事投稿が無効であること' do
     post = build(:post, user_id: user.id, title: nil)
     post.valid?
-    expect(post.errors[:title]).to include('を入力してください')
+    expect(post.errors[:title]).to include('この記事の投稿は難しいようです')
   end
 
   it '重複したURLが存在するなら記事投稿が無効であること' do

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -7,9 +7,21 @@ RSpec.describe 'Posts', type: :system do
   let!(:post) { create(:post, user_id: user.id) }
 
   describe 'index' do
+    let(:user2) { create(:g_user) }
     let!(:post2) { create(:post2, user_id: user.id) }
     let!(:post3) { create(:post3, user_id: user.id) }
     let!(:post4) { create(:post4, user_id: user.id) }
+    let!(:like) { create(:like, user_id: user.id, post_id: post2.id) }
+    let!(:like2) { create(:like2, user_id: user.id, post_id: post3.id) }
+    let!(:like3) { create(:like, user_id: user2.id, post_id: post3.id) }
+
+    it '標準では人気順で記事が並んでいること' do
+      visit root_path
+      within '.posts' do
+        post_title = all('.title').map(&:text)
+        expect(post_title).to eq %w[1日前の記事 10分前の記事 2日前の記事 看護記事]
+      end
+    end
 
     it 'タブから記事を新着順に並び替えること' do
       visit root_path

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -11,13 +11,8 @@ RSpec.describe 'Posts', type: :system do
     let!(:post3) { create(:post3, user_id: user.id) }
     let!(:post4) { create(:post4, user_id: user.id) }
 
-    it '標準では人気順で記事が並んでいること' do
-      skip
-      visit posts_path
-    end
-
     it 'タブから記事を新着順に並び替えること' do
-      visit posts_path
+      visit root_path
       find('a', text: '新着順').click
       within '.posts' do
         post_title = all('.title').map(&:text)
@@ -37,7 +32,6 @@ RSpec.describe 'Posts', type: :system do
   describe 'create' do
     it 'サインインしたユーザーが記事投稿すること' do
       sign_in_as(user)
-      visit posts_path
       expect do
         click_on '記事を投稿する'
         fill_in 'URL',	with: 'https://example.net'
@@ -48,7 +42,6 @@ RSpec.describe 'Posts', type: :system do
 
     it '重複したURL記事では投稿できないこと' do
       sign_in_as(user)
-      visit posts_path
       expect do
         click_on '記事を投稿する'
         fill_in 'URL',	with: 'https://example.com'
@@ -58,7 +51,7 @@ RSpec.describe 'Posts', type: :system do
     end
 
     it 'サインインしていないユーザーは記事投稿ができないこと' do
-      visit posts_path
+      visit root_path
       click_on '記事を投稿する'
       fill_in 'URL',	with: 'https://example.com'
       click_on '記事の投稿'


### PR DESCRIPTION
- #109 
- #111 

無効なURLが投稿された際にエラー画面へ遷移だけだったので、例外処理を行いエラーメッセージを表示させた
・hogeなどURLそのものが無効なもの
 ・twitterのツイートなどURLは有効であるが、metaタグにて情報取得できないもの
に対応した
それに伴いテストも修正

不要なファイルを消した