### PR TITLE
httpをhttpsにリダイレクトさせるようにした

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
[Can Heroku force an application to use SSL/TLS? \- Heroku Help](https://help.heroku.com/J2R1S4T8/can-heroku-force-an-application-to-use-ssl-tls)を参考に