### PR TITLE
OGPデータを取得できないページも投稿できるようにした

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,6 +9,10 @@ class PostsController < ApplicationController
     @posts = Post.all
   end
 
+  def new
+    @post = Post.new
+  end
+
   def show
     @comment = Comment.new
     @comments = @post.comments.includes(:user)
@@ -17,12 +21,13 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.new(post_params)
 
-    begin
-      @post.scrape
-    rescue StandardError
-      flash.now[:alert] = 'この記事(URL)の投稿はできませんでした'
-      render :index
-      return
+    unless @post.title
+      begin
+        @post.scrape
+        return render :new if @post.title.empty?
+      rescue StandardError
+        return render :new
+      end
     end
 
     if @post.save
@@ -45,6 +50,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:url)
+    params.require(:post).permit(:url, :title, :site_name, :image_url)
   end
 end

--- a/app/views/home/_description.slim
+++ b/app/views/home/_description.slim
@@ -37,12 +37,9 @@ article.description
             .content
               ul
                 li
-                  | 看護記事のURLをこちらに入れて「記事の投稿」をクリック
+                  | 看護記事のURLをこちらに入れて「記事の投稿」をクリック。
                 li
-                  | URLがある記事であれば投稿できます<br>(twitterにはまだ対応できていません)
-                li
-                  | PDFファイルは登録できないので、論文を投稿する際には、<br>
-                  | J-StageやCiNiiなどリンクされている論文検索サービスのURLを投稿してください
+                  | PDFファイルの論文もURLがあれば投稿可能です。
           = form_with(model: @post, local: true) do |form|
             .content
               = render 'shared/errors', object: @post

--- a/app/views/home/_description.slim
+++ b/app/views/home/_description.slim
@@ -51,6 +51,6 @@ article.description
               .field-body.is-grouped
                 .field.is-expanded
                   .control
-                    = form.text_field :url, class: 'input'
+                    = form.text_field :url, class: 'input', placeholder: 'https://www.example.com'
                 .control
                   = form.submit '記事の投稿', class: 'button is-right is-primary'

--- a/app/views/posts/new.html.slim
+++ b/app/views/posts/new.html.slim
@@ -1,0 +1,1 @@
+h1 Post#new

--- a/app/views/posts/new.html.slim
+++ b/app/views/posts/new.html.slim
@@ -1,1 +1,27 @@
-h1 Post#new
+article.article.container
+  h2.title.is-3 新規記事登録
+  = form_with(model: @post, local: true) do |form|
+    = form.hidden_field :image_url, value: 'logo_picks.png'
+    = form.hidden_field :url
+    .field
+      .label
+        = form.label :title, 'サイトURL'
+      .control
+        = @post.url
+    .field
+      .label
+        = form.label :title, '記事の題名'
+    .field
+      .control
+        = form.text_field :title, class: 'input'
+    .field
+      .label
+        = form.label :site_name, 'サイト元(任意)'
+    .field
+      .control
+        = form.text_field :site_name, class: 'input'
+    .control
+      .buttons.is-right
+        = form.submit '記事の登録', class: 'button is-primary'
+
+  = link_to '戻る', root_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 
 Rails.application.routes.draw do
   root 'posts#index'
-  resources :posts, only: %i(show create destroy) do
+  resources :posts, only: %i(new show create destroy) do
     resources :comments, only: %i(create destroy)
     resource :likes, only: %i(create destroy)
   end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -69,6 +69,35 @@ RSpec.describe 'Posts', type: :system do
       click_on '記事の投稿'
       expect(page).to have_content 'ログインしてください'
     end
+
+    context 'MetaInspectorで記事が作れない場合' do
+      before do
+        sign_in_as(user)
+        click_on '記事を投稿する'
+      end
+
+      it 'Twitterなどメタ情報はあるが、タイトルがとれない記事を投稿すること' do
+        expect do
+          fill_in 'URL',	with: 'https://twitter.com/nurse_picks'
+          click_on '記事の投稿'
+          expect(page).to have_content '新規記事登録'
+          fill_in 'post_title', with: 'NursePicks公式Twitter'
+          click_on '記事の登録'
+          expect(page).to have_content '「NursePicks公式Twitter」を登録しました'
+        end.to change { Post.count }.by(1)
+      end
+
+      it 'pdfなどメタ情報がとれない記事を投稿すること' do
+        expect do
+          fill_in 'URL',	with: 'https://www.kansaigaidai.ac.jp/asp/img/pdf/82/7a79c35f7ce0704dec63be82440c8182.pdf'
+          click_on '記事の投稿'
+          expect(page).to have_content '新規記事登録'
+          fill_in 'post_title', with: 'サンプルPDF'
+          click_on '記事の登録'
+          expect(page).to have_content '「サンプルPDF」を登録しました'
+        end.to change { Post.count }.by(1)
+      end
+    end
   end
 
   describe 'destroy' do

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -70,28 +70,31 @@ RSpec.describe 'Posts', type: :system do
       expect(page).to have_content 'ログインしてください'
     end
 
-    context 'MetaInspectorで記事が作れない場合' do
+    context 'MetaInspectorでogpデータが取れない場合' do
       before do
         sign_in_as(user)
         click_on '記事を投稿する'
       end
 
-      it 'Twitterなどメタ情報はあるが、タイトルがとれない記事を投稿すること' do
+      it 'タイトルなど取得できない情報を追加し、記事を投稿すること' do
         expect do
-          fill_in 'URL',	with: 'https://twitter.com/nurse_picks'
+          fill_in 'URL', with: 'https://twitter.com/nurse_picks'
           click_on '記事の投稿'
           expect(page).to have_content '新規記事登録'
+          expect(page).to have_content 'https://twitter.com/nurse_picks'
+          expect(page).to have_field 'サイト元(任意)', with: 'Twitter'
           fill_in 'post_title', with: 'NursePicks公式Twitter'
           click_on '記事の登録'
           expect(page).to have_content '「NursePicks公式Twitter」を登録しました'
         end.to change { Post.count }.by(1)
       end
 
-      it 'pdfなどメタ情報がとれない記事を投稿すること' do
+      it 'pdfファイルでもリンクがあれば投稿できること' do
         expect do
-          fill_in 'URL',	with: 'https://www.kansaigaidai.ac.jp/asp/img/pdf/82/7a79c35f7ce0704dec63be82440c8182.pdf'
+          fill_in 'URL', with: 'https://www.kansaigaidai.ac.jp/asp/img/pdf/82/7a79c35f7ce0704dec63be82440c8182.pdf'
           click_on '記事の投稿'
           expect(page).to have_content '新規記事登録'
+          expect(page).to have_content 'https://www.kansaigaidai.ac.jp/asp/img/pdf/82/7a79c35f7ce0704dec63be82440c8182.pdf'
           fill_in 'post_title', with: 'サンプルPDF'
           click_on '記事の登録'
           expect(page).to have_content '「サンプルPDF」を登録しました'


### PR DESCRIPTION
# OGPデータを取得できないページも投稿できるようにした
## issue
- #114 
- #54 

## before
[MetaInspector](https://github.com/metainspector/metainspector)というgemを使用して、URLからOGPデータ(ページのタイトル、画像、サイト元)を取得。
取得できないページに関しては全てエラーを返し、記事投稿できないようにしていた。

## after
URLからOGPデータを取得できなければpost#newへ遷移させ、自分でサイト名とサイト元を入力。記事投稿を可能にさせた。

https://user-images.githubusercontent.com/69446373/192470211-547fe6ab-2048-43bc-84b8-da060c3401cc.mov


