### PR TITLE
記事にタグをつけられるようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :test do
   gem 'webdrivers'
 end
 
+gem 'acts-as-taggable-on'
 gem 'dotenv-rails'
 gem 'html2slim'
 gem 'metainspector'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    acts-as-taggable-on (9.0.1)
+      activerecord (>= 6.0, < 7.1)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
@@ -410,6 +412,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  acts-as-taggable-on
   bootsnap (>= 1.4.4)
   bullet
   byebug

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -4,7 +4,7 @@ class API::PostsController < ApplicationController
   before_action :require_signin, only: %i[destroy]
 
   def index
-    @posts = Post.includes(:comments, :likes)
+    @posts = Post.includes(:comments, :likes, :tags, :tag_taggings)
   end
 
   def destroy

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -24,7 +24,7 @@ class PostsController < ApplicationController
     unless @post.title
       begin
         @post.scrape
-        return render :new if @post.title.empty?
+        return render :new
       rescue StandardError
         return render :new
       end
@@ -34,7 +34,7 @@ class PostsController < ApplicationController
       redirect_to @post, notice: "「#{@post.title}」を登録しました"
     else
       flash.now[:alert] = "記事投稿に失敗しました。#{@post.errors.full_messages[0]}。"
-      render :index
+      render :new
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -50,6 +50,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:url, :title, :site_name, :image_url)
+    params.require(:post).permit(:url, :title, :site_name, :image_url, :tag_list)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -26,6 +26,7 @@ class PostsController < ApplicationController
         @post.scrape
         return render :new
       rescue StandardError
+        @post.image_url = 'logo_picks.png'
         return render :new
       end
     end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,5 +3,6 @@ import '../posts.js'
 import '../user.js'
 import '../modal.js'
 import '../menu.js'
+import '../post-tags.js'
 
 Rails.start()

--- a/app/javascript/packs/application.scss
+++ b/app/javascript/packs/application.scss
@@ -54,3 +54,4 @@ $tabs-link-color: #808080;
 @import "~bulma/sass/layout/all";
 
 @import 'vue-toast-notification/dist/theme-sugar.css';
+@import 'choices.js/public/assets/styles/choices.min.css';

--- a/app/javascript/packs/application.scss
+++ b/app/javascript/packs/application.scss
@@ -42,6 +42,7 @@ $tabs-link-color: #808080;
 @import '../stylesheets/footer.scss';
 @import '../stylesheets/notification.scss';
 @import '../stylesheets/user.scss';
+@import '../stylesheets/tags.scss';
 
 // Import only what you need from Bulma
 @import "~bulma/sass/utilities/all";

--- a/app/javascript/post-tags.js
+++ b/app/javascript/post-tags.js
@@ -1,0 +1,18 @@
+import Choices from 'choices.js'
+
+
+document.addEventListener('DOMContentLoaded', () => {
+  const elementMultipleSelect = document.getElementById(
+    'js-post-tags'
+  )
+  if (elementMultipleSelect) {
+    return new Choices(elementMultipleSelect, {
+      allowHTML: true,
+      delimiter: ',',
+      removeItemButton: true,
+      addItemText: (value) => {
+        return `Enterを押すと<b>「${value}」</b>のタグが追加されます`;
+      }
+    })
+  }
+})

--- a/app/javascript/post-tags.js
+++ b/app/javascript/post-tags.js
@@ -1,17 +1,14 @@
 import Choices from 'choices.js'
 
-
 document.addEventListener('DOMContentLoaded', () => {
-  const elementMultipleSelect = document.getElementById(
-    'js-post-tags'
-  )
-  if (elementMultipleSelect) {
-    return new Choices(elementMultipleSelect, {
+  const element = document.getElementById('js-post-tags')
+  if (element) {
+    return new Choices(element, {
       allowHTML: true,
       delimiter: ',',
       removeItemButton: true,
       addItemText: (value) => {
-        return `Enterを押すと<b>「${value}」</b>のタグが追加されます`;
+        return `Enterを押すと<b>「${value}」</b>のタグが追加されます`
       }
     })
   }

--- a/app/javascript/posts.vue
+++ b/app/javascript/posts.vue
@@ -26,9 +26,12 @@ section.container
         .title.is-6
           a(:href='post.url', target='_blank', rel='noopener') {{ post.title }}
         .sub-title
-          span.sub-title-text
+          span
             | {{ post.site_name }}
             | {{ post.date }}
+          span.post-tags
+            span.post-tag(v-for='tag in post.tags')
+              | {{ tag }}
       .media-right.comment-link(:class="{'has-comment': post.comments_count != 0}")
         a(:href='post.show_url')
           i.fa-solid.fa-message.fa-2x

--- a/app/javascript/posts.vue
+++ b/app/javascript/posts.vue
@@ -31,7 +31,7 @@ section.container
             | {{ post.date }}
           span.post-tags
             span.post-tag(v-for='tag in post.tags')
-              | {{ tag }}
+              | {{ tag.name }}
       .media-right.comment-link(:class="{'has-comment': post.comments_count != 0}")
         a(:href='post.show_url')
           i.fa-solid.fa-message.fa-2x

--- a/app/javascript/stylesheets/post.scss
+++ b/app/javascript/stylesheets/post.scss
@@ -146,10 +146,6 @@
   }
 }
 
-.show-post {
-  margin-top: 30px;
-}
-
 .new-post-image {
   img {
     object-fit: contain;

--- a/app/javascript/stylesheets/post.scss
+++ b/app/javascript/stylesheets/post.scss
@@ -149,3 +149,16 @@
 .show-post {
   margin-top: 30px;
 }
+
+.new-post-image {
+  img {
+    object-fit: contain;
+    height: 160px;
+  }
+  img[src*='logo_picks'] {
+    filter: grayscale(100%);
+    background: #c9c9c9;
+    padding: 10px;
+    opacity: .6;
+  }
+}

--- a/app/javascript/stylesheets/post.scss
+++ b/app/javascript/stylesheets/post.scss
@@ -39,8 +39,17 @@
 .sub-title {
   font-size: 14px;
   margin-top: -20px;
-  .sub-title-text {
-    color: $black;
+}
+
+.post-tags {
+  margin: 2px;
+  .post-tag {
+    color: $white;
+    border-radius: 6px;
+    background-color: $orange;
+    border: 1px solid $white;
+    font-size: 12px;
+    padding: 2px;
   }
 }
 

--- a/app/javascript/stylesheets/tags.scss
+++ b/app/javascript/stylesheets/tags.scss
@@ -1,0 +1,23 @@
+.choices__inner {
+  background-color: $white;
+  border-color: hsl(0deg, 0%, 86%);
+  border-radius: 4px;
+  border: 2px solid hsl(0deg, 0%, 86%);
+}
+
+.choices__list--multiple .choices__item {
+  border-radius: 6px;
+  background-color: $orange;
+  border: 1px solid $white;
+  .choices__button {
+    border-left: 1px solid $white;
+  }
+  &.is-highlighted {
+    background-color: $orange;
+    border: 1px solid $white;
+  }
+}
+
+.choices__input {
+  background-color: $white;
+}

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,6 +6,7 @@ class Post < ApplicationRecord
   has_many :likes, dependent: :destroy
   validates :url, presence: true, uniqueness: true
   validates :title, presence: true
+  acts_as_taggable_on :tags
 
   after_create TweetNotifier.new
 

--- a/app/views/api/posts/_post.json.jbuilder
+++ b/app/views/api/posts/_post.json.jbuilder
@@ -6,10 +6,13 @@ json.image_url post.image_url
 json.user_id post.user_id
 json.created_at post.created_at
 json.date l(post.created_at, format: :short)
+json.comments post.comments
 json.comments_count post.comments.size
 json.show_url post_url(post)
 json.likes post.likes
 json.likes_id post.likes.pluck(:id)
 json.like_users post.likes.pluck(:user_id)
 json.likes_count post.likes.size
-json.tags post.tag_list
+json.tags post.tags do |tag|
+  json.name tag.name
+end

--- a/app/views/api/posts/_post.json.jbuilder
+++ b/app/views/api/posts/_post.json.jbuilder
@@ -6,10 +6,10 @@ json.image_url post.image_url
 json.user_id post.user_id
 json.created_at post.created_at
 json.date l(post.created_at, format: :short)
-json.comments post.comments
 json.comments_count post.comments.size
 json.show_url post_url(post)
 json.likes post.likes
 json.likes_id post.likes.pluck(:id)
 json.like_users post.likes.pluck(:user_id)
 json.likes_count post.likes.size
+json.tags post.tag_list

--- a/app/views/posts/new.html.slim
+++ b/app/views/posts/new.html.slim
@@ -10,7 +10,7 @@ article.article.container
         = @post.url
     .field
       .label
-        = form.label :title, '記事の題名'
+        = form.label :title, '記事のタイトル'
     .field
       .control
         = form.text_field :title, class: 'input'

--- a/app/views/posts/new.html.slim
+++ b/app/views/posts/new.html.slim
@@ -23,6 +23,7 @@ article.article.container
     .field
       .label
         = form.label :tag_list, 'タグ(循環器、小児、終末期、論文など)', for: 'js-post-tags'
+    .field
       .control
         = text_field_tag 'post[tag_list]', @post.tag_list.join(","), type: 'text', id: 'js-post-tags' 
     .control

--- a/app/views/posts/new.html.slim
+++ b/app/views/posts/new.html.slim
@@ -20,6 +20,11 @@ article.article.container
     .field
       .control
         = form.text_field :site_name, class: 'input'
+    .field
+      .label
+        = form.label :tag_list, 'タグ(循環器、小児、終末期、論文など)'
+      .control
+        = text_field_tag 'post[tag_list]', @post.tag_list.join(",")
     .control
       .buttons.is-right
         = form.submit '記事の登録', class: 'button is-primary'

--- a/app/views/posts/new.html.slim
+++ b/app/views/posts/new.html.slim
@@ -22,9 +22,9 @@ article.article.container
         = form.text_field :site_name, class: 'input'
     .field
       .label
-        = form.label :tag_list, 'タグ(循環器、小児、終末期、論文など)'
+        = form.label :tag_list, 'タグ(循環器、小児、終末期、論文など)', for: 'js-post-tags'
       .control
-        = text_field_tag 'post[tag_list]', @post.tag_list.join(",")
+        = text_field_tag 'post[tag_list]', @post.tag_list.join(","), type: 'text', id: 'js-post-tags' 
     .control
       .buttons.is-right
         = form.submit '記事の登録', class: 'button is-primary'

--- a/app/views/posts/new.html.slim
+++ b/app/views/posts/new.html.slim
@@ -1,7 +1,12 @@
 article.article.container
   h2.title.is-3 新規記事登録
   = form_with(model: @post, local: true) do |form|
-    = form.hidden_field :image_url, value: 'logo_picks.png'
+    .field
+      .label
+        = form.label :image_url, 'このサイトの画像'
+      .new-post-image
+        = image_tag(@post.image_url, alt: 'post_image')
+    = form.hidden_field :image_url
     = form.hidden_field :url
     .field
       .label
@@ -25,7 +30,7 @@ article.article.container
         = form.label :tag_list, 'タグ(循環器、小児、終末期、論文など)', for: 'js-post-tags'
     .field
       .control
-        = text_field_tag 'post[tag_list]', @post.tag_list.join(","), type: 'text', id: 'js-post-tags' 
+        = text_field_tag 'post[tag_list]', @post.tag_list.join(','), type: 'text', id: 'js-post-tags'
     .control
       .buttons.is-right
         = form.submit '記事の登録', class: 'button is-primary'

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -8,10 +8,10 @@ article.article.container
       .media-content
         h2.title.is-5
           = link_to @post.title, @post.url, target: :_blank, rel: 'noopener'
-        .sub-title
-          i.fa-solid.fa-message
-          |  #{@post.comments.count}
-          |  #{@post.site_name}
+        .sub-title.issue-tag-container
+          = @post.site_name
+          - @post.tag_list.each do |tag_name|
+            = tag_name
       .media-right.has-text-centered
         - if current_user
           - if current_user.liked?(@post)

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -8,7 +8,7 @@ article.article.container
       .media-content
         h2.title.is-5
           = link_to @post.title, @post.url, target: :_blank, rel: 'noopener'
-        .sub-title.issue-tag-container
+        .sub-title
           = @post.site_name
           - @post.tag_list.each do |tag_name|
             = tag_name

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -10,8 +10,10 @@ article.article.container
           = link_to @post.title, @post.url, target: :_blank, rel: 'noopener'
         .sub-title
           = @post.site_name
-          - @post.tag_list.each do |tag_name|
-            = tag_name
+          span.post-tags
+            - @post.tag_list.each do |tag|
+              span.post-tag
+                = tag
       .media-right.has-text-centered
         - if current_user
           - if current_user.liked?(@post)

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -1,10 +1,9 @@
 article.article.container
-  section.show-post
-    .media
+  section
+    .post.media
       .media-left
-        .post-image
-          .image.is-64x64
-            = image_tag(@post.image_url, alt: 'post_image')
+        = link_to @post.url, target: :_blank, rel: 'noopener', class: 'post-image'
+          = image_tag @post.image_url, alt: 'post_image', class: 'image is-64x64'
       .media-content
         h2.title.is-5
           = link_to @post.title, @post.url, target: :_blank, rel: 'noopener'

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -10,7 +10,7 @@ ja:
       post:
         image_url: 画像のURL  #g
         site_name: サイト名  #g
-        title: 記事
+        title: タイトル
         url: URL  #g
         user: :activerecord.models.user  #g
         comments: コメント  #g
@@ -34,12 +34,3 @@ ja:
       like:
         post: :activerecord.models.post  #g
         user: :activerecord.models.user  #g
-
-    errors:
-      # format: '%{message}'
-      models:
-        post:
-          attributes:
-            title:
-              format: '%{message}'
-              blank: この記事の投稿は難しいようです

--- a/db/migrate/20220928151816_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20220928151816_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+
+class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20220928151817_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20220928151817_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+
+class AddMissingUniqueIndices < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20220928151818_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20220928151818_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20220928151819_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20220928151819_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+
+class AddMissingTaggableIndex < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20220928151820_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20220928151820_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+
+class ChangeCollationForTagNames < ActiveRecord::Migration[6.0]
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20220928151821_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20220928151821_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+
+class AddMissingIndexesOnTaggings < ActiveRecord::Migration[6.0]
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                 :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                   :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                               :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                         name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                name: 'taggings_idy'
+    end
+  end
+end

--- a/db/migrate/20220928151822_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20220928151822_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 7)
+
+class AddTenantToTaggings < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.taggings_table, :tenant, :string, limit: 128
+    add_index ActsAsTaggableOn.taggings_table, :tenant unless index_exists? ActsAsTaggableOn.taggings_table, :tenant
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, :tenant
+    remove_column ActsAsTaggableOn.taggings_table, :tenant
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_12_095015) do
+ActiveRecord::Schema.define(version: 2022_09_28_151822) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,37 @@ ActiveRecord::Schema.define(version: 2022_06_12_095015) do
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
+  create_table "taggings", force: :cascade do |t|
+    t.bigint "tag_id"
+    t.string "taggable_type"
+    t.bigint "taggable_id"
+    t.string "tagger_type"
+    t.bigint "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.string "tenant", limit: 128
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+    t.index ["tagger_type", "tagger_id"], name: "index_taggings_on_tagger_type_and_tagger_id"
+    t.index ["tenant"], name: "index_taggings_on_tenant"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "icon_url"
@@ -63,4 +94,5 @@ ActiveRecord::Schema.define(version: 2022_06_12_095015) do
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"
+  add_foreign_key "taggings", "tags"
 end

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.3",
     "bulma": "^0.9.4",
+    "choices.js": "^10.1.0",
     "pug": "^3.0.2",
     "pug-plain-loader": "^1.1.0",
     "rails-ujs": "^5.2.8",

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Post, type: :model do
   it 'タイトルがなければ記事投稿が無効であること' do
     post = build(:post, user_id: user.id, title: nil)
     post.valid?
-    expect(post.errors[:title]).to include('この記事の投稿は難しいようです')
+    expect(post.errors[:title]).to include('を入力してください')
   end
 
   it '重複したURLが存在するなら記事投稿が無効であること' do

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe 'Posts', type: :system do
         click_on '記事を投稿する'
         fill_in 'URL',	with: 'https://example.net'
         click_on '記事の投稿'
+        expect(page).to have_field '記事のタイトル', with: 'Example Domain'
+        click_on '記事の登録'
         expect(page).to have_content '「Example Domain」を登録しました'
       end.to change { Post.count }.by(1)
     end
@@ -58,7 +60,9 @@ RSpec.describe 'Posts', type: :system do
         click_on '記事を投稿する'
         fill_in 'URL',	with: 'https://example.com'
         click_on '記事の投稿'
-        expect(page).to have_content '記事投稿に失敗しました'
+        expect(page).to have_field '記事のタイトル', with: 'Example Domain'
+        click_on '記事の登録'
+        expect(page).to have_content '記事投稿に失敗しました。URLはすでに存在します。'
       end.to change { Post.count }.by(0)
     end
 
@@ -80,7 +84,6 @@ RSpec.describe 'Posts', type: :system do
         expect do
           fill_in 'URL', with: 'https://twitter.com/nurse_picks'
           click_on '記事の投稿'
-          expect(page).to have_content '新規記事登録'
           expect(page).to have_content 'https://twitter.com/nurse_picks'
           expect(page).to have_field 'サイト元(任意)', with: 'Twitter'
           fill_in 'post_title', with: 'NursePicks公式Twitter'
@@ -93,7 +96,6 @@ RSpec.describe 'Posts', type: :system do
         expect do
           fill_in 'URL', with: 'https://www.kansaigaidai.ac.jp/asp/img/pdf/82/7a79c35f7ce0704dec63be82440c8182.pdf'
           click_on '記事の投稿'
-          expect(page).to have_content '新規記事登録'
           expect(page).to have_content 'https://www.kansaigaidai.ac.jp/asp/img/pdf/82/7a79c35f7ce0704dec63be82440c8182.pdf'
           fill_in 'post_title', with: 'サンプルPDF'
           click_on '記事の登録'

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,6 +880,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.9.2":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -2182,6 +2189,15 @@ character-parser@^2.2.0:
   dependencies:
     is-regex "^1.0.3"
 
+choices.js@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/choices.js/-/choices.js-10.1.0.tgz#034a40b7aa82e2a38f19ff8fae5bbfa6047862f4"
+  integrity sha512-NtrFt7c7ZQEGmkWsAV+EHynJhADWoZ82JEfg1+vQ9MMKJD4Ax2rzYPxXe+Q64i0HgUgWG/XTN3gN2pB8UFFFlA==
+  dependencies:
+    deepmerge "^4.2.2"
+    fuse.js "^6.5.3"
+    redux "^4.1.2"
+
 "chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
@@ -2806,6 +2822,11 @@ deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
 default-gateway@^6.0.3:
   version "6.0.3"
@@ -3743,6 +3764,11 @@ functions-have-names@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
+fuse.js@^6.5.3:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.6.2.tgz#fe463fed4b98c0226ac3da2856a415576dc9a111"
+  integrity sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -6661,6 +6687,13 @@ rechoir@^0.7.0:
   integrity sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==
   dependencies:
     resolve "^1.9.0"
+
+redux@^4.1.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
+  integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 regenerate-unicode-properties@^10.0.1:
   version "10.0.1"


### PR DESCRIPTION
- #113

[acts-as-taggable-on](https://github.com/mbleigh/acts-as-taggable-on)を利用し看護記事にタグをつけられるようにした。
<img width="990" alt="image" src="https://user-images.githubusercontent.com/69446373/193406257-52a645f3-3044-4227-92a0-663d8c82a999.png">

[Choices.js](https://github.com/Choices-js/Choices)を導入することで動的にタブをつけられるようにもした

https://user-images.githubusercontent.com/69446373/193406557-4cb996f5-d0d7-4691-b9e9-b985e7b1fa83.mov

今後はタブを利用し看護記事を検索できるようにしていく予定
- #115 
