### PR TITLE
Release Phaseを使い本番環境のmigrate忘れを防止

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
-rails: bin/rails s -p 3000
-webpack-dev-server: bin/webpack-dev-server
+release: bin/rails db:migrate


### PR DESCRIPTION
[Herokuにpushしたらdb:migrateしよう\(HerokuのRelease Phaseについても\) \- 832\.59](https://garammasala29.hatenablog.com/entry/2022/10/04/165410)