### PR TITLE
サービスの説明を隠せるようにし、cookieで保存できるようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ end
 
 group :test do
   gem 'capybara', github: 'teamcapybara/capybara'
-  gem 'webdrivers'
+  gem 'webdrivers', '~> 5.2.0'
 end
 
 gem 'acts-as-taggable-on'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,10 +337,11 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.1.0)
+    selenium-webdriver (4.5.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     semantic_range (3.0.0)
     simple_oauth (0.3.1)
     slim (4.1.0)
@@ -391,7 +392,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.0.0)
+    webdrivers (5.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
@@ -400,6 +401,7 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -445,7 +447,7 @@ DEPENDENCIES
   twitter
   tzinfo-data
   web-console (>= 4.1.0)
-  webdrivers
+  webdrivers (~> 5.2.0)
   webpacker (~> 5.0)
 
 RUBY VERSION

--- a/app/javascript/hide-usage.js
+++ b/app/javascript/hide-usage.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
       usage.classList.toggle('is-hidden')
       message.classList.toggle('is-hidden')
       if (document.cookie === 'nursepicks_usage=hide') {
-        document.cookie = "nursepicks_usage="
+        document.cookie = 'nursepicks_usage='
       } else {
         document.cookie = 'nursepicks_usage=hide'
       }

--- a/app/javascript/hide-usage.js
+++ b/app/javascript/hide-usage.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const elements = document.querySelectorAll('#js-hide-usage')
+  for (const element of elements) {
+    element.addEventListener('click', () => {
+      const usage = document.querySelector('.usage')
+      if (usage) {
+        usage.style.display = 'none'
+      } 
+      // if (document.cookie === 'nursepicks_usage=hide') {
+      //   document.cookie = "nursepicks_usage=''"
+      //   const usage = element.getAttribute('data-usage')
+      //   document.getElementById(usage).classList.toggle('is-active')
+      // } else {
+      //   document.cookie = 'nursepicks_usage=hide'
+      //   const usage = element.getAttribute('data-usage')
+      //   document.getElementById(usage).classList.toggle('is-active')
+      // }
+    })
+  }
+})

--- a/app/javascript/hide-usage.js
+++ b/app/javascript/hide-usage.js
@@ -3,26 +3,24 @@ document.addEventListener('DOMContentLoaded', () => {
   const usage = document.querySelector('.usage')
   const message = document.querySelector('.hide-usage-message')
   for (const element of elements) {
-    if (usage.style.display === 'block') {
-      element.addEventListener('click', () => {
-        usage.style.display = 'none'
-        message.style.display = 'block'
-      })
-    } else {
-      element.addEventListener('click', () => {
-        usage.style.display = 'block'
-        message.style.display = 'none'
-      })
-    }
+    element.addEventListener('click', () => {
+      usage.classList.toggle('is-hidden')
+      message.classList.toggle('is-hidden')
+    })
+
+
+    // if (document.cookie === 'nursepicks_usage=hide') {
+    //   element.addEventListener('click', () => {
+    //     document.cookie = "nursepicks_usage=''"
+    //     message.style.display = 'none'
+    //     usage.style.display = 'block'
+    //   })
+    // } else {
+    //   element.addEventListener('click', () => {
+    //     document.cookie = 'nursepicks_usage=hide'
+    //     usage.style.display = 'none'
+    //     message.style.display = 'block'
+    //   })
+    // }
   }
 })
-
-// if (document.cookie === 'nursepicks_usage=hide') {
-//   document.cookie = "nursepicks_usage=''"
-//   const usage = element.getAttribute('data-usage')
-//   document.getElementById(usage).classList.toggle('is-active')
-// } else {
-//   document.cookie = 'nursepicks_usage=hide'
-//   const usage = element.getAttribute('data-usage')
-//   document.getElementById(usage).classList.toggle('is-active')
-// }

--- a/app/javascript/hide-usage.js
+++ b/app/javascript/hide-usage.js
@@ -1,20 +1,28 @@
 document.addEventListener('DOMContentLoaded', () => {
   const elements = document.querySelectorAll('#js-hide-usage')
+  const usage = document.querySelector('.usage')
+  const message = document.querySelector('.hide-usage-message')
   for (const element of elements) {
-    element.addEventListener('click', () => {
-      const usage = document.querySelector('.usage')
-      if (usage) {
+    if (usage.style.display === 'block') {
+      element.addEventListener('click', () => {
         usage.style.display = 'none'
-      } 
-      // if (document.cookie === 'nursepicks_usage=hide') {
-      //   document.cookie = "nursepicks_usage=''"
-      //   const usage = element.getAttribute('data-usage')
-      //   document.getElementById(usage).classList.toggle('is-active')
-      // } else {
-      //   document.cookie = 'nursepicks_usage=hide'
-      //   const usage = element.getAttribute('data-usage')
-      //   document.getElementById(usage).classList.toggle('is-active')
-      // }
-    })
+        message.style.display = 'block'
+      })
+    } else {
+      element.addEventListener('click', () => {
+        usage.style.display = 'block'
+        message.style.display = 'none'
+      })
+    }
   }
 })
+
+// if (document.cookie === 'nursepicks_usage=hide') {
+//   document.cookie = "nursepicks_usage=''"
+//   const usage = element.getAttribute('data-usage')
+//   document.getElementById(usage).classList.toggle('is-active')
+// } else {
+//   document.cookie = 'nursepicks_usage=hide'
+//   const usage = element.getAttribute('data-usage')
+//   document.getElementById(usage).classList.toggle('is-active')
+// }

--- a/app/javascript/hide-usage.js
+++ b/app/javascript/hide-usage.js
@@ -6,21 +6,11 @@ document.addEventListener('DOMContentLoaded', () => {
     element.addEventListener('click', () => {
       usage.classList.toggle('is-hidden')
       message.classList.toggle('is-hidden')
+      if (document.cookie === 'nursepicks_usage=hide') {
+        document.cookie = "nursepicks_usage="
+      } else {
+        document.cookie = 'nursepicks_usage=hide'
+      }
     })
-
-
-    // if (document.cookie === 'nursepicks_usage=hide') {
-    //   element.addEventListener('click', () => {
-    //     document.cookie = "nursepicks_usage=''"
-    //     message.style.display = 'none'
-    //     usage.style.display = 'block'
-    //   })
-    // } else {
-    //   element.addEventListener('click', () => {
-    //     document.cookie = 'nursepicks_usage=hide'
-    //     usage.style.display = 'none'
-    //     message.style.display = 'block'
-    //   })
-    // }
   }
 })

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,5 +3,6 @@ import '../posts.js'
 import '../user.js'
 import '../modal.js'
 import '../post-tags.js'
+import '../hide-usage.js'
 
 Rails.start()

--- a/app/javascript/stylesheets/description.scss
+++ b/app/javascript/stylesheets/description.scss
@@ -72,3 +72,16 @@
     min-width: calc(100vw - 2rem);
   }
 }
+
+.hide-usage-message {
+  text-align: right;
+  a {
+    color: #444444;
+    text-decoration: underline;
+  }
+}
+
+.hide-usage-button {
+  text-align: right;
+  margin-bottom: 10px;
+}

--- a/app/views/home/_description.slim
+++ b/app/views/home/_description.slim
@@ -5,23 +5,25 @@ article.description
     p
       | 看護師で作る、看護記事ブックマークサイト
   section.description-content.container
-    .columns
-      .column
-        .using
-          h3.title.is-5.has-text-centered
-            | 探す・読む
-          .using-image.has-text-centered
-            = image_tag('icon_read.png', size: '96x96', alt: 'read_icon')
-          .subtitle.is-6
-            p 投稿された価値ある看護記事や論文を、簡単に読むことができます。<br>記事に付けられたコメントも確認できます。
-      .column
-        .using
-          h3.title.is-5.has-text-centered
-            | 投稿する
-          .using-image.has-text-centered
-            = image_tag('icon_post.png', size: '96x96', alt: 'post_icon')
-          .subtitle.is-6
-            p 看護に役立つ記事・論文のURLを登録してください。<br>自分で書いた記事やYouTubeもURLがあれば投稿できます。<br>記事を投稿したりコメントするには、アカウント登録が必要です。
+    .usage
+      button.delete.is-large#js-hide-usage
+      .columns
+        .column
+          .using
+            h3.title.is-5.has-text-centered
+              | 探す・読む
+            .using-image.has-text-centered
+              = image_tag('icon_read.png', size: '96x96', alt: 'read_icon')
+            .subtitle.is-6
+              p 投稿された価値ある看護記事や論文を、簡単に読むことができます。<br>記事に付けられたコメントも確認できます。
+        .column
+          .using
+            h3.title.is-5.has-text-centered
+              | 投稿する
+            .using-image.has-text-centered
+              = image_tag('icon_post.png', size: '96x96', alt: 'post_icon')
+            .subtitle.is-6
+              p 看護に役立つ記事・論文のURLを登録してください。<br>自分で書いた記事やYouTubeもURLがあれば投稿できます。<br>記事を投稿したりコメントするには、アカウント登録が必要です。
   section.description-button
     button.button.is-primary.is-large.post-button#js-modal data-modal='post-modal'
       | 記事を投稿する

--- a/app/views/home/_description.slim
+++ b/app/views/home/_description.slim
@@ -34,7 +34,7 @@ article.description
         a#js-hide-usage
           | このサイトの使い方
       .usage
-        .hide-usage-button      
+        .hide-usage-button
           button.delete.is-large#js-hide-usage
         .columns
           .column

--- a/app/views/home/_description.slim
+++ b/app/views/home/_description.slim
@@ -5,28 +5,52 @@ article.description
     p
       | 看護師で作る、看護記事ブックマークサイト
   section.description-content.container
-    .hide-usage-message.is-hidden
-      button#js-hide-usage
-        | このサイトの使い方
-    .usage
-      button.delete.is-large#js-hide-usage
-      .columns
-        .column
-          .using
-            h3.title.is-5.has-text-centered
-              | 探す・読む
-            .using-image.has-text-centered
-              = image_tag('icon_read.png', size: '96x96', alt: 'read_icon')
-            .subtitle.is-6
-              p 投稿された価値ある看護記事や論文を、簡単に読むことができます。<br>記事に付けられたコメントも確認できます。
-        .column
-          .using
-            h3.title.is-5.has-text-centered
-              | 投稿する
-            .using-image.has-text-centered
-              = image_tag('icon_post.png', size: '96x96', alt: 'post_icon')
-            .subtitle.is-6
-              p 看護に役立つ記事・論文のURLを登録してください。<br>自分で書いた記事やYouTubeもURLがあれば投稿できます。<br>記事を投稿したりコメントするには、アカウント登録が必要です。
+    - if cookies[:nursepicks_usage] == 'hide'
+      .hide-usage-message
+        button#js-hide-usage
+          | このサイトの使い方
+      .usage.is-hidden
+        button.delete.is-large#js-hide-usage
+        .columns
+          .column
+            .using
+              h3.title.is-5.has-text-centered
+                | 探す・読む
+              .using-image.has-text-centered
+                = image_tag('icon_read.png', size: '96x96', alt: 'read_icon')
+              .subtitle.is-6
+                p 投稿された価値ある看護記事や論文を、簡単に読むことができます。<br>記事に付けられたコメントも確認できます。
+          .column
+            .using
+              h3.title.is-5.has-text-centered
+                | 投稿する
+              .using-image.has-text-centered
+                = image_tag('icon_post.png', size: '96x96', alt: 'post_icon')
+              .subtitle.is-6
+                p 看護に役立つ記事・論文のURLを登録してください。<br>自分で書いた記事やYouTubeもURLがあれば投稿できます。<br>記事を投稿したりコメントするには、アカウント登録が必要です。
+    - else
+      .hide-usage-message.is-hidden
+        button#js-hide-usage
+          | このサイトの使い方
+      .usage
+        button.delete.is-large#js-hide-usage
+        .columns
+          .column
+            .using
+              h3.title.is-5.has-text-centered
+                | 探す・読む
+              .using-image.has-text-centered
+                = image_tag('icon_read.png', size: '96x96', alt: 'read_icon')
+              .subtitle.is-6
+                p 投稿された価値ある看護記事や論文を、簡単に読むことができます。<br>記事に付けられたコメントも確認できます。
+          .column
+            .using
+              h3.title.is-5.has-text-centered
+                | 投稿する
+              .using-image.has-text-centered
+                = image_tag('icon_post.png', size: '96x96', alt: 'post_icon')
+              .subtitle.is-6
+                p 看護に役立つ記事・論文のURLを登録してください。<br>自分で書いた記事やYouTubeもURLがあれば投稿できます。<br>記事を投稿したりコメントするには、アカウント登録が必要です。
   section.description-button
     button.button.is-primary.is-large.post-button#js-modal data-modal='post-modal'
       | 記事を投稿する

--- a/app/views/home/_description.slim
+++ b/app/views/home/_description.slim
@@ -5,8 +5,8 @@ article.description
     p
       | 看護師で作る、看護記事ブックマークサイト
   section.description-content.container
-    .hide-usage-message
-      p#js-hide-usage
+    .hide-usage-message.is-hidden
+      button#js-hide-usage
         | このサイトの使い方
     .usage
       button.delete.is-large#js-hide-usage

--- a/app/views/home/_description.slim
+++ b/app/views/home/_description.slim
@@ -7,10 +7,11 @@ article.description
   section.description-content.container
     - if cookies[:nursepicks_usage] == 'hide'
       .hide-usage-message
-        button#js-hide-usage
+        a#js-hide-usage
           | このサイトの使い方
       .usage.is-hidden
-        button.delete.is-large#js-hide-usage
+        .hide-usage-button
+          button.delete.is-large#js-hide-usage
         .columns
           .column
             .using
@@ -30,10 +31,11 @@ article.description
                 p 看護に役立つ記事・論文のURLを登録してください。<br>自分で書いた記事やYouTubeもURLがあれば投稿できます。<br>記事を投稿したりコメントするには、アカウント登録が必要です。
     - else
       .hide-usage-message.is-hidden
-        button#js-hide-usage
+        a#js-hide-usage
           | このサイトの使い方
       .usage
-        button.delete.is-large#js-hide-usage
+        .hide-usage-button      
+          button.delete.is-large#js-hide-usage
         .columns
           .column
             .using

--- a/app/views/home/_description.slim
+++ b/app/views/home/_description.slim
@@ -5,6 +5,9 @@ article.description
     p
       | 看護師で作る、看護記事ブックマークサイト
   section.description-content.container
+    .hide-usage-message
+      p#js-hide-usage
+        | このサイトの使い方
     .usage
       button.delete.is-large#js-hide-usage
       .columns


### PR DESCRIPTION

https://user-images.githubusercontent.com/69446373/196224767-c31fba83-f8d5-4080-9c3f-4d84e2d07622.mov

説明文が幅をとり、スクロールの邪魔になるので、コンパクトに収納できるようにした。
また、cookieで保存することで、再度訪問したときも閉じた状態が維持されるようにした。

※ `app/views/home/_description.slim`のコードが冗長なので、リファクタリングの必要がありそう